### PR TITLE
Let TravisCI install standard via pretest script. Use standard@5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: "node_js"
 node_js:
   - "4.2"
   - "5.0"
-before_script:
-  - npm install standard
-  - standard
 script:
   - npm install istanbul
   - istanbul cover ./node_modules/.bin/_mocha --report lcovonly

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "preferGlobal": true,
   "license": "MIT",
   "scripts": {
-    "pretest": "standard --version || npm -g install standard",
+    "pretest": "standard --version || npm -g install standard@5",
     "test": "mocha && standard",
-    "preformat": "standard --version || npm -g install standard",
+    "preformat": "standard --version || npm -g install standard@5",
     "format": "standard --format",
     "thought": "thought run -a",
     "prethoughtcheck": "thought --version || npm -g install thought",


### PR DESCRIPTION
- There is an issue with standard@6.0.1 and node 4.2
  https://github.com/feross/standard/issues/406