### PR TITLE
Use q-io@2 to exclude wrongly implemented "Array.prototype.find"-method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "4.2"
-  - "5.0"
+  - "4"
+  - "5"
+  - "6"
 script:
   - npm install istanbul
   - istanbul cover ./node_modules/.bin/_mocha --report lcovonly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
  matrix:
   - nodejs_version: "4"
   - nodejs_version: "5"
+  - nodejs_version: "6"
   
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -6,7 +6,7 @@
  */
 'use strict'
 
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var path = require('path')
 var qcp = require('../lib/q-child-process.js')
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -7,7 +7,7 @@
 'use strict'
 
 var cpp = require('../lib/q-child-process')
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var path = require('path')
 var moment = require('moment')
 var debug = require('debug')('thoughtful-release:git')

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -8,7 +8,7 @@
 
 var path = require('path')
 var semver = require('semver')
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var Q = require('q')
 var _ = {
   defaultsDeep: require('lodash.defaultsdeep')

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash.toarray": "^3.0.2",
     "moment": "^2.11.1",
     "q": "^1.4.1",
-    "q-io": "^1.13.2",
+    "q-io": "^2.0.6",
     "semver": "^5.1.0"
   },
   "devDependencies": {
@@ -68,7 +68,7 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "thoughtful precommit && standard && thought run -a"
+      "pre-commit": "thoughtful precommit && standard"
     }
   },
   "keywords": []

--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "lodash.isplainobject": "^3",
     "lodash.isstring": "^3.0.1",
     "lodash.toarray": "^3.0.2",
+    "m-io": "*",
+    "mkdirp": "^0.5.1",
     "moment": "^2.11.1",
     "q": "^1.4.1",
-    "q-io": "^2.0.6",
     "semver": "^5.1.0"
   },
   "devDependencies": {

--- a/test/changelog-spec.js
+++ b/test/changelog-spec.js
@@ -21,7 +21,7 @@ var expect = chai.expect
 var changelog = require('../lib/changelog.js')
 var qfs = require('q-io/fs')
 var path = require('path')
-require('trace')
+require('./trace')
 
 function fixture (filename) {
   return require('fs').readFileSync(path.join('test', 'fixtures', filename), {encoding: 'utf-8'})

--- a/test/changelog-spec.js
+++ b/test/changelog-spec.js
@@ -19,7 +19,7 @@ var chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 var expect = chai.expect
 var changelog = require('../lib/changelog.js')
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var path = require('path')
 require('./trace')
 

--- a/test/git-spec.js
+++ b/test/git-spec.js
@@ -18,7 +18,7 @@ var chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 var expect = chai.expect
 var git = require('../lib/git.js')
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var Q = require('q')
 var path = require('path')
 require('./trace')

--- a/test/git-spec.js
+++ b/test/git-spec.js
@@ -21,6 +21,7 @@ var git = require('../lib/git.js')
 var qfs = require('q-io/fs')
 var Q = require('q')
 var path = require('path')
+require('./trace')
 
 describe('git-library:', () => {
   afterEach(() => {

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-require('trace')
+require('./trace')
 
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -123,9 +123,14 @@ describe('main-module:', () => {
       this.timeout(5000)
       // Update changelog and bump version
       var changelogContents = thoughtful.updateChangelog({release: 'minor'})
-        .then(() => qcp.execFile('npm', ['version', 'minor'], {cwd: workDir()}))
-        // On Windows, we need to call the '.cmd' file
-        .catch(() => qcp.execFile('npm.cmd', ['version', 'minor'], {cwd: workDir()}))
+        .then(() => {
+          if (process.platform.match(/^win/i)) {
+            // On Windows, we need to call the '.cmd' file
+            return qcp.execFile('npm.cmd', ['version', 'minor'], {cwd: workDir()})
+          } else {
+            return qcp.execFile('npm', ['version', 'minor'], {cwd: workDir()})
+          }
+        })
         // Add another file
         .then(() => qfs.write(workDir('index.js'), "'use strict'"))
         .then(() => qcp.execFile('git', ['add', 'index.js'], {cwd: workDir()}))

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -23,7 +23,7 @@ var chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 var expect = chai.expect
 var qcp = require('../lib/q-child-process')
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var path = require('path')
 var Q = require('q')
 var _ = {

--- a/test/npm-spec.js
+++ b/test/npm-spec.js
@@ -17,6 +17,7 @@ var chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 var expect = chai.expect
 var npm = require('../lib/npm.js')
+require('./trace')
 
 describe('The npm-helper lib:', () => {
   describe('The version method', () => {

--- a/test/q-child-process-spec.js
+++ b/test/q-child-process-spec.js
@@ -19,6 +19,7 @@ chai.use(chaiAsPromised)
 var expect = chai.expect
 var path = require('path')
 var qcp = require('../lib/q-child-process')
+require('./trace')
 
 describe('q-child-process-library:', () => {
   describe('the spawn-method', () => {

--- a/test/trace.js
+++ b/test/trace.js
@@ -1,0 +1,9 @@
+/**
+ * A shortcut for loding `trace` only with compatible versions (i.e. node 6)
+ */
+
+'use strict'
+
+if (process.version.match(/v6/)) {
+  require('trace')
+}


### PR DESCRIPTION
This method is injected in the `collections`-package as array-shim, which is a dependency of q-io.
Version 1.x of `collections` implements the method with the semantics of `Array.prototype.findIndex`
instead. This leads to problems with other packages that rely on the implementation as defined in the ES6-Standard  See also: https://github.com/montagejs/collections/issues/139Use q-io@2 to exclude wrongly implemented "Array.prototype.find"-method  This method is injected in the `collections`-package as array-shim, which is a dependency of q-io. Version 1.x of `collections` implements the method with the semantics of `Array.prototype.findIndex` instead. This leads to problems with other packages that rely on the implementation as defined in the ES6-Standard  See also: https://github.com/montagejs/collections/issues/139
